### PR TITLE
index.html: fix link to auditability blog post

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
     But there have been concerns about possible inflation bugs in the Monero codebase or the underlying math principles which could be exploited to generate coins out of thin air. In may 2017 the Monero Research Lab discovered and patched a critical bug that affected Monero and would have allowed an exploiter to create an unlimited number of coins in a way that is undetectable to an observer unless they know about the fatal flaw and can search for it.
     <br>
     This particular bug however was confirmed to have never been used before on the Monero blockchain.
-    Read more about supply auditability <a href="https://web.getmonero.org/2020/01/17/auditability.html">here</a>
+    Read more about supply auditability <a href="https://www.getmonero.org/2020/01/17/auditability.html">here</a>
 </p>
 <h2>
     About


### PR DESCRIPTION
The canonical address is `https://www.getmonero.org`. Using `web` will result in a cache skip.